### PR TITLE
Fix multi-core on x86_64

### DIFF
--- a/crates/mmu/src/ptmapper.rs
+++ b/crates/mmu/src/ptmapper.rs
@@ -160,13 +160,7 @@ where
     }
 
     /// Prints the permissions of page tables for the given range.
-    pub fn debug_range(
-        &mut self,
-        virt_addr: VirtAddr,
-        size: usize,
-        dept: Level,
-        print: impl Fn(core::fmt::Arguments),
-    ) {
+    pub fn debug_range(&mut self, virt_addr: VirtAddr, size: usize, dept: Level) {
         unsafe {
             self.walk_range(
                 virt_addr,
@@ -193,14 +187,14 @@ where
                             Level::L2 => "    ",
                             Level::L1 => "      ",
                         };
-                        print(core::format_args!(
+                        log::info!(
                             "{}{:?} Virt: 0x{:x} - Phys: 0x{:x} - {:?}\n",
                             padding,
                             level,
                             addr.as_usize(),
                             phys,
                             flags
-                        ));
+                        );
                         WalkNext::Continue
                     } else {
                         WalkNext::Leaf

--- a/crates/stage_two_abi/src/lib.rs
+++ b/crates/stage_two_abi/src/lib.rs
@@ -63,10 +63,19 @@ pub struct Manifest {
     pub vga: VgaInfo,
     /// Optionnal address of the I/O MMU. Absent if set to 0.
     pub iommu: u64,
+    /// SMP info:
+    pub smp: Smp,
+}
+
+/// Suport for x86_64 SMP
+#[repr(C)]
+pub struct Smp {
     /// SMP info: number of available cores
     pub smp: usize,
     /// ACPI MP Wakeup Mailbox Address
-    pub mp_mailbox: u64,
+    pub mailbox: u64,
+    /// The CR3 value for MP wakeup
+    pub wakeup_cr3: u64,
 }
 
 impl Manifest {
@@ -109,8 +118,11 @@ macro_rules! make_manifest {
                 info: $crate::GuestInfo::default_config(),
                 vga: $crate::VgaInfo::no_vga(),
                 iommu: 0,
-                smp: 0,
-                mp_mailbox: 0,
+                smp: $crate::Smp {
+                    smp: 0,
+                    mailbox: 0,
+                    wakeup_cr3: 0,
+                },
             };
             static TAKEN: AtomicBool = AtomicBool::new(false);
 

--- a/monitor/first-stage/src/elf/mod.rs
+++ b/monitor/first-stage/src/elf/mod.rs
@@ -288,6 +288,11 @@ impl ElfProgram {
         assert!(segment.p_offset + segment.p_filesz <= self.bytes.len() as u64);
 
         // Prepare destination
+        log::debug!(
+            "Loading segment [0x{:x}, 0x{:x}]",
+            segment.p_paddr,
+            segment.p_paddr + segment.p_memsz
+        );
         let dest = core::slice::from_raw_parts_mut(
             (segment.p_paddr + host_physical_offset.as_u64()) as *mut u8,
             segment.p_filesz as usize,

--- a/monitor/first-stage/src/mmu/frames.rs
+++ b/monitor/first-stage/src/mmu/frames.rs
@@ -143,7 +143,14 @@ impl BootInfoFrameAllocator {
             allocator
                 .goto_next_region()
                 .expect("No usable memory region");
+        } else {
+            log::debug!(
+                "Allocating from [0x{:x}, 0x{:x}]",
+                memory_map[0].start,
+                memory_map[0].end
+            );
         }
+
         // Allocate one frame, so that we don't use frame zero
         allocator
             .allocate_frame()
@@ -198,6 +205,11 @@ impl BootInfoFrameAllocator {
 
             // Check if usable
             if self.memory_map[self.region_idx].kind == MemoryRegionKind::Usable {
+                log::debug!(
+                    "Allocating from [0x{:x}, 0x{:x}]",
+                    self.memory_map[self.region_idx].start,
+                    self.memory_map[self.region_idx].end
+                );
                 self.next_frame = self.memory_map[self.region_idx].start;
                 return Ok(());
             }
@@ -280,6 +292,11 @@ impl RangeFrameAllocator {
         range_end: HostPhysAddr,
         physical_memory_offset: HostVirtAddr,
     ) -> Self {
+        log::debug!(
+            "Allocator range: [0x{:x}, 0x{:x}]",
+            range_start.as_usize(),
+            range_end.as_usize()
+        );
         let range_start = range_start.align_up(PAGE_SIZE).as_u64();
         let range_end = range_end.align_down(PAGE_SIZE).as_u64();
         Self {

--- a/monitor/tyche/src/x86_64/vmx_helper.rs
+++ b/monitor/tyche/src/x86_64/vmx_helper.rs
@@ -29,9 +29,6 @@ pub unsafe fn init_vcpu<'vmx>(vcpu: &mut ActiveVmcs<'vmx>, info: &GuestInfo) {
     vcpu.set_nat(fields::GuestStateNat::Cr3, info.cr3).ok();
     vcpu.set_nat(fields::GuestStateNat::Rsp, info.rsp).ok();
     vcpu.set(Register::Rsi, info.rsi as u64);
-    // Zero out the gdt and idt.
-    vcpu.set_nat(fields::GuestStateNat::GdtrBase, 0x0).ok();
-    vcpu.set_nat(fields::GuestStateNat::IdtrBase, 0x0).ok();
     // VMXE flags, required during VMX operations.
     let vmxe = 1 << 13;
     let cr4 = 0xA0 | vmxe;
@@ -71,7 +68,9 @@ fn default_vmcs_config(vmcs: &mut ActiveVmcs, info: &GuestInfo, switching: bool)
         )
     );
 
-    let mut secondary_ctrls = SecondaryControls::ENABLE_RDTSCP | SecondaryControls::ENABLE_EPT;
+    let mut secondary_ctrls = SecondaryControls::ENABLE_RDTSCP
+        | SecondaryControls::ENABLE_EPT
+        | SecondaryControls::UNRESTRICTED_GUEST;
     if switching {
         secondary_ctrls |= SecondaryControls::ENABLE_VM_FUNCTIONS
     }

--- a/scripts/tyche-gdb
+++ b/scripts/tyche-gdb
@@ -29,4 +29,4 @@ else
   print_usage
 fi
 
-rust-gdb -q -ex "file target/x86_64-kernel/debug/first-stage" -ex "target remote ${DBG}" -ex "source scripts/tyche-gdb.gdb" -ex "${TGT}"
+rust-gdb -q -ex "file target/x86_64-kernel/debug/s1" -ex "target remote ${DBG}" -ex "source scripts/tyche-gdb.gdb" -ex "${TGT}"

--- a/scripts/tyche-gdb.gdb
+++ b/scripts/tyche-gdb.gdb
@@ -26,9 +26,9 @@ define symbol_rawc
 end
 
 define symbol_linux
-  add-symbol-file linux-image/images/vmlinux
+  add-symbol-file builds/linux-x86/vmlinux
   set $tyche_guest_image=1
-  source linux-image/builds/linux-tyche-embedded/vmlinux-gdb.py
+  source builds/linux-x86/vmlinux-gdb.py
   #lx-symbols
 end
 

--- a/scripts/tyche_debug.py
+++ b/scripts/tyche_debug.py
@@ -73,7 +73,7 @@ class TycheLoadStage2(gdb.Command):
 
     def invoke(self, arg, from_tty):
         offset = get_convenience("STAGE2_VOFF")
-        gdb.execute("add-symbol-file target/x86_64-unknown-kernel/release/second-stage")
+        gdb.execute("add-symbol-file target/x86_64-unknown-kernel/release/tyche")
 
 """ Starts the remote gdb session attached to the debugger/debugger executable.
 The remote gdb session executes until QEMU file-backed memory is mmaped into


### PR DESCRIPTION
The multi-core was broken on x86_64, the APs where hitting a page fault right on the wakeup vector. This commits adds "wakeup" page tables to ensure that Linux do not overwrite the page tables we provide initially.