### PR TITLE
Fixing debug_range bug

### DIFF
--- a/crates/mmu/src/eptmapper.rs
+++ b/crates/mmu/src/eptmapper.rs
@@ -67,6 +67,9 @@ impl EptMapper {
                         return WalkNext::Leaf;
                     }
                     log::info!("{:?} -> 0x{:x} | {:x?}", level, addr.as_usize(), entry);
+                    if (*entry & EptEntryFlags::PAGE.bits()) != 0 {
+                        return WalkNext::Leaf;
+                    }
                     return WalkNext::Continue;
                 },
             )


### PR DESCRIPTION
debug_range in epts did not take into account huge/giant entries which lead to a fault in the VMM.