### PR TITLE
Out of memory error were printed accidently

### DIFF
--- a/crates/capability-engine/src/domain.rs
+++ b/crates/capability-engine/src/domain.rs
@@ -362,7 +362,7 @@ pub(crate) fn create_switch(
     domains: &mut DomainPool,
     contexts: &mut ContextPool,
 ) -> Result<LocalCapa, CapaError> {
-    let context = contexts.allocate(Context::new()).ok_or({
+    let context = contexts.allocate(Context::new()).ok_or_else(|| {
         log::trace!("Unable to allocate context for switch!");
         CapaError::OutOfMemory
     })?;

--- a/crates/capability-engine/src/lib.rs
+++ b/crates/capability-engine/src/lib.rs
@@ -118,7 +118,7 @@ impl CapaEngine {
         self.cores[core_id].initialize(domain)?;
         self.domains[domain].execute_on_core(core_id);
 
-        self.contexts.allocate(Context::new()).ok_or({
+        self.contexts.allocate(Context::new()).ok_or_else(|| {
             log::trace!("Unable to allocate context!");
             CapaError::OutOfMemory
         })
@@ -304,7 +304,7 @@ impl CapaEngine {
         capa: LocalCapa,
     ) -> Result<(LocalCapa, Handle<Context>), CapaError> {
         let capa = self.domains[domain].get(capa)?.as_management()?;
-        let context = self.contexts.allocate(Context::new()).ok_or({
+        let context = self.contexts.allocate(Context::new()).ok_or_else(|| {
             log::trace!("Unable to allocate context for seal!");
             CapaError::OutOfMemory
         })?;

--- a/crates/capability-engine/src/region.rs
+++ b/crates/capability-engine/src/region.rs
@@ -314,7 +314,7 @@ impl RegionTracker {
             ref_count: region.ref_count,
             next: region.next,
         };
-        let second_half_handle = self.regions.allocate(second_half).ok_or({
+        let second_half_handle = self.regions.allocate(second_half).ok_or_else(|| {
             log::trace!("Unable to allocate new region!");
             CapaError::OutOfMemory
         })?;
@@ -347,7 +347,7 @@ impl RegionTracker {
         let handle = self
             .regions
             .allocate(Region::new(start, end).set_next(region.next))
-            .ok_or({
+            .ok_or_else(|| {
                 log::trace!("Unable to allocate new region!");
                 CapaError::OutOfMemory
             })?;
@@ -367,7 +367,7 @@ impl RegionTracker {
         }
 
         let region = Region::new(start, end).set_next(self.head);
-        let handle = self.regions.allocate(region).ok_or({
+        let handle = self.regions.allocate(region).ok_or_else(|| {
             log::trace!("Unable to allocate new region!");
             CapaError::OutOfMemory
         })?;


### PR DESCRIPTION
The `ok_or` function always compute its argument eagerly, so they were printing the error message **before** the actual call to the function. By replacing them by `ok_or_else`, the else branch is a closure that is only executed if None is received.