### PR TITLE
Add removing context design doc

### DIFF
--- a/design/001-design-doc.md
+++ b/design/001-design-doc.md
@@ -2,30 +2,23 @@
 
 ## What?
 
-In order to make communication easier and keep track of the decisions we made, I
-propose to introduce *design documents* in which we document our choices.
+In order to make communication easier and keep track of the decisions we made, I propose to introduce *design documents* in which we document our choices.
 This document itself is the first design document.
 
 ## Why?
 
 While iterating on the Tyche project, we have to make a lot of design decisions.
-Those decisions needs to be communicated to the whole team, as they may impact
-multiple aspect of the projects.
-Sometimes, some decisions are not trivial and might need proper discussion, and
-once a path is decided it is good to keep a trace of why this decision was made.
+Those decisions needs to be communicated to the whole team, as they may impact multiple aspect of the projects.
+Sometimes, some decisions are not trivial and might need proper discussion, and once a path is decided it is good to keep a trace of why this decision was made.
 
 ## How?
 
-I propose that we document our most important decisions, as well as decisions
-implying trade-off or design choice when the design space is not obvious.
-This process should not take too much time, ideally the design documents are
-kept short and should be written in ~10 minutes at most.
+I propose that we document our most important decisions, as well as decisions implying trade-off or design choice when the design space is not obvious.
+This process should not take too much time, ideally the design documents are kept short and should be written in ~10 minutes at most.
 
-To keep the structure simple and understandable, I propose a "what", "why",
-"how" format, like for this document:
+To keep the structure simple and understandable, I propose a "what", "why", "how" format, like for this document:
 - **what**: What is the document about/what should we change?
 - **why**: Why doing thing this way? Are there other options?
 - **how**: How will the new solution work? What are the changes?
 
-In addition, I propose to give the documents names starting with a unique ID,
-e.g. `001` for this document, to keep them sorted easily.
+In addition, I propose to give the documents names starting with a unique ID, e.g. `001` for this document, to keep them sorted easily.

--- a/design/002-removing-contexts.md
+++ b/design/002-removing-contexts.md
@@ -2,37 +2,23 @@
 
 ## What?
 
-The capability engine has a notion of "context", which represents an execution
-context for a given domain (e.g. registers such as program counter). When a
-domain is scheduled on a core, it is scheduled with a given context.
-I propose to remove the notion of context, and instead to have an implicit
-per-core context for each domain.
+The capability engine has a notion of "context", which represents an execution context for a given domain (e.g. registers such as program counter).
+When a domain is scheduled on a core, it is scheduled with a given context.
+I propose to remove the notion of context, and instead to have an implicit per-core context for each domain.
 
 ## Why?
 
-The contexts were originally introduced to make the programming model easier: it
-is possible to do calls into the domain, return and then resume the call.
-This programming model looks a lot like SGX for instance, where contexts are TCS
-(thread control structures).
-Contexts works well with switches (calls into a domain), but they are not well
-suited for handling interrupts and exceptions.
-Indeed, we need to select a context when a domain must be scheduled to handle an
-interrupt or because a domain it manages was killed.
+The contexts were originally introduced to make the programming model easier: it is possible to do calls into the domain, return and then resume the call.
+This programming model looks a lot like SGX for instance, where contexts are TCS (thread control structures).
+Contexts works well with switches (calls into a domain), but they are not well suited for handling interrupts and exceptions.
+Indeed, we need to select a context when a domain must be scheduled to handle an interrupt or because a domain it manages was killed.
 
-Unfortunately, creating a new context can fail due to OOM, which prevents the
-manager domain to be scheduled on the core, putting the system in state where a
-panic is the only sensible solution.
-A solution to this shortcoming would be to pre-allocate contexts for exception
-handling. But as context can be kept alive indefinitely, we still need to
-allocate a fresh context for the next exception and thus delaying the problem
-without solving it.
+Unfortunately, creating a new context can fail due to OOM, which prevents the manager domain to be scheduled on the core, putting the system in state where a panic is the only sensible solution.
+A solution to this shortcoming would be to pre-allocate contexts for exception handling.
+But as context can be kept alive indefinitely, we still need to allocate a fresh context for the next exception and thus delaying the problem without solving it.
 
-Another more philosophical issue I have with context is that they are a "high
-level" construct, basically threads, which feels odd to implement into the
-isolation monitor.
-Having a single "core" abstraction, with one context per core, would feel more
-in line with the rest of the isolation monitor design, as a monitor exposing the
-hardware directly.
+Another more philosophical issue I have with context is that they are a "high level" construct, basically threads, which feels odd to implement into the isolation monitor.
+Having a single "core" abstraction, with one context per core, would feel more in line with the rest of the isolation monitor design, as a monitor exposing the hardware directly.
 
 ## How?
 
@@ -41,18 +27,13 @@ The monitor itself will still keep a per-core and per-domain context.
 
 There are two mains implications: for context switches, and for interrupts.
 
-- Context switches become a bit more complicated, as the thread abstraction (if
-  desired) must be implemented in the domains. Fortunately, this will not change
-  much for our existing enclave application, as they rely on a single context.
-  The user-level thread can be implemented by having a small trampoline as the
-  entry point, that then switches the stack, PC and base registers to match the
-  expected context.
+- Context switches become a bit more complicated, as the thread abstraction (if desired) must be implemented in the domains.
+  Fortunately, this will not change much for our existing enclave application, as they rely on a single context.
+  The user-level thread can be implemented by having a small trampoline as the entry point, that then switches the stack, PC and base registers to match the expected context.
 - Exceptions becomes much simpler to implement: they match the hardware
   exception model.
-  A domain would have an exception handler, basically a PC, and a `iret`
-  mechanism to switch back to the domain that caused the exception if any.
+  A domain would have an exception handler, basically a PC, and a `iret` mechanism to switch back to the domain that caused the exception if any.
   
-  The remaining question with this approach is how to re-inject interrupts in
-  Linux? We can have the exception handler in the Tyche driver, but things such
-  as e.g. interrupt timer must be forwarded to Linux.
+  The remaining question with this approach is how to re-inject interrupts in Linux?
+  We can have the exception handler in the Tyche driver, but things such as e.g. interrupt timer must be forwarded to Linux.
 


### PR DESCRIPTION
We will have to handle contexts in the presence of exceptions, so here is a first design proposal. Still up to discussion, but I feel like the best way forward is to get rid of the contexts and keep an implicit per-core per-domain context.