### PR TITLE
Fixing cargo install bug

### DIFF
--- a/C/libraries/sdktyche/example/app-selector/Makefile
+++ b/C/libraries/sdktyche/example/app-selector/Makefile
@@ -64,7 +64,7 @@ enclave: $(CODE_ENCLAVE) $(HDRS_ENCLAVE)
 	gcc -DTYCHE_USER_SPACE=1 -g $(COMMON_INCLUDES) -nostdlib -static -o $@ $(CODE_ENCLAVE)
 
 app_selector: app enclave
-	cargo -C $(TYCHOOLS_PATH) install --path .
+	cargo -C $(TYCHOOLS_PATH) install --path . --locked
 	tychools instrument -s manifests/default.json 
 	chmod +x app_selector
 	rm app enclave

--- a/C/libraries/sdktyche/example/simple-enclave/Makefile
+++ b/C/libraries/sdktyche/example/simple-enclave/Makefile
@@ -78,7 +78,7 @@ enclave_iso: app enclave
 	rm app enclave
 
 attestation_enclave: app enclave
-	cargo -C $(TYCHOOLS_PATH) install --path .
+	cargo -C $(TYCHOOLS_PATH) install --path . --locked
 	tychools instrument -s manifests/default.json 
 	chmod +x simple_enclave
 	tychools instrument -s manifests/enclave_iso.json 

--- a/C/libraries/sdktyche/example/simple-sandbox/Makefile
+++ b/C/libraries/sdktyche/example/simple-sandbox/Makefile
@@ -64,7 +64,7 @@ sandbox: $(CODE_SANDBOX) $(HDRS_SANDBOX)
 	gcc -DTYCHE_USER_SPACE=1 -DTYCHOOLS=1 -g $(COMMON_INCLUDES) -nostdlib -static -o $@ $(CODE_SANDBOX)
 
 instrument: app sandbox 
-	cargo -C $(TYCHOOLS_PATH) install --path .
+	cargo -C $(TYCHOOLS_PATH) install --path . --locked
 	tychools instrument -s manifests/default.json 
 	chmod +x application_with_sandbox
 	rm app sandbox

--- a/C/libraries/tyche-trusted-runtime/Makefile
+++ b/C/libraries/tyche-trusted-runtime/Makefile
@@ -65,7 +65,7 @@ loader: $(CODE_APP) $(HDRS_APP)
 	gcc -DTYCHE_USER_SPACE=1 -g $(APP_INCLUDES) -o $@ $(CODE_APP)
 
 test-trt: loader trt
-	cargo -C $(TYCHOOLS_PATH) install --path .
+	cargo -C $(TYCHOOLS_PATH) install --path . --locked
 	tychools instrument -s manifests/config.json
 	chmod +x test-trt
 	rm -rf loader trt

--- a/crates/tychools/src/attestation.rs
+++ b/crates/tychools/src/attestation.rs
@@ -1,7 +1,7 @@
 use std::fs::read_to_string;
 use std::path::PathBuf;
 
-use ed25519_compact::{PublicKey, SecretKey, Signature};
+use ed25519_compact::{PublicKey, Signature};
 use object::elf::{PF_R, PF_W, PF_X};
 use object::read::elf::ProgramHeader;
 use sha2::{Digest, Sha256};
@@ -137,7 +137,7 @@ pub fn attestation_check(src_bin: &PathBuf, src_att: &PathBuf, offset: u64, nonc
     copy_arr(&mut message, &u64::to_le_bytes(nonce), 32);
     {
         let mut data_file = File::create("tychools_response.txt").expect("creation failed");
-        if let Ok(r) = pkey.verify(message, &sig) {
+        if let Ok(_r) = pkey.verify(message, &sig) {
             log::info!("Verified!");
             data_file.write(b"Message verified").expect("Write failed");
         } else {

--- a/crates/tychools/src/elf_modifier.rs
+++ b/crates/tychools/src/elf_modifier.rs
@@ -670,7 +670,7 @@ impl ModifiedELF {
     pub fn set_attestation_hash(&mut self) {
         for seg in &mut self.segments {
             if ModifiedSegment::is_loadable(seg.program_header.p_type(DENDIAN)) {
-                if let Some(tpe) = TychePhdrTypes::from_u32(seg.program_header.p_type(DENDIAN)) {
+                if let Some(_tpe) = TychePhdrTypes::from_u32(seg.program_header.p_type(DENDIAN)) {
                     if seg.should_include_attestation() {
                         seg.set_mask_flags(PF_H);
                     }


### PR DESCRIPTION
Passing the locked option prevents it from trying to install newer versions for packages that are incompatible with our rustc version.

Fixing warnings in tychools too.