### PR TITLE
Capa-engine: use a global region pool instead of per-domain

### DIFF
--- a/crates/capability-engine/examples/main.rs
+++ b/crates/capability-engine/examples/main.rs
@@ -1,4 +1,4 @@
-use capa_engine::{permission, AccessRights, CapaEngine, Domain, Handle, MemOps, MEMOPS_ALL};
+use capa_engine::{permission, AccessRights, CapaEngine, Domain, Handle, MemOps};
 use simple_logger::SimpleLogger;
 
 fn main() {
@@ -9,22 +9,7 @@ fn main() {
         .init()
         .unwrap();
 
-    // bar();
     foo();
-}
-
-#[allow(unused)]
-fn bar() {
-    let mut pool = capa_engine::RegionTracker::new();
-
-    pool.add_region(0x200, 0x300, MEMOPS_ALL).unwrap();
-    println!("{}", &pool);
-    pool.add_region(0x300, 0x400, MEMOPS_ALL).unwrap();
-    println!("{}", &pool);
-    pool.add_region(0x100, 0x500, MEMOPS_ALL).unwrap();
-    println!("{}", &pool);
-    pool.remove_region(0x200, 0x400, MEMOPS_ALL).unwrap();
-    println!("{}", &pool);
 }
 
 #[allow(unused)]
@@ -108,12 +93,19 @@ fn display(_engine: &CapaEngine) {
     // println!("{}", engine.get_regions());
 }
 
-fn display_domain(domain: Handle<Domain>, engine: &CapaEngine) {
-    let domain = &engine[domain];
-    println!("Domain {} {}", domain.id(), domain.regions());
+fn display_domain(handle: Handle<Domain>, engine: &CapaEngine) {
+    let domain = &engine[handle];
+    println!(
+        "Domain {} {}",
+        domain.id(),
+        &engine.get_domain_regions(handle).expect("Invalid domain")
+    );
     print!("         {{");
     let mut first = true;
-    for area in domain.regions().permissions() {
+    for area in engine
+        .get_domain_permissions(handle)
+        .expect("Invalid domain")
+    {
         if first {
             first = false;
         } else {

--- a/crates/capability-engine/tests/main.rs
+++ b/crates/capability-engine/tests/main.rs
@@ -1,7 +1,7 @@
 use std::fmt::Write;
 
 use capa_engine::{
-    permission, AccessRights, CapaEngine, Domain, Handle, MemOps, NextCapaToken, RegionTracker,
+    permission, AccessRights, CapaEngine, Domain, Handle, MemOps, NextCapaToken, RegionIterator,
     MEMOPS_ALL,
 };
 
@@ -508,8 +508,8 @@ fn access_rights_test() {
 
 // ————————————————————————————————— Utils —————————————————————————————————— //
 
-fn regions(domain: Handle<Domain>, engine: &CapaEngine) -> &RegionTracker {
-    engine[domain].regions()
+fn regions(domain: Handle<Domain>, engine: &CapaEngine) -> RegionIterator {
+    engine.get_domain_regions(domain).expect("Invalid domain")
 }
 
 fn capas(domain: Handle<Domain>, engine: &mut CapaEngine) -> String {

--- a/monitor/tyche/src/riscv/monitor.rs
+++ b/monitor/tyche/src/riscv/monitor.rs
@@ -267,7 +267,7 @@ pub fn do_debug() {
             next_capa = next_next_capa;
             log::debug!(" - {}", info);
         }
-        log::debug!("{}", engine[domain].regions());
+        log::debug!("{}", engine.get_domain_regions(domain).unwrap());
     }
 }
 
@@ -478,7 +478,7 @@ fn update_permission(domain_handle: Handle<Domain>, engine: &mut MutexGuard<Capa
     clear_pmp();
     let mut pmp_write_result: Result<PMPAddressingMode, PMPErrorCode>;
     let mut pmp_index = FROZEN_PMP_ENTRIES;
-    for range in engine[domain_handle].regions().permissions() {
+    for range in engine.get_domain_permissions(domain_handle).unwrap() {
         if !range.ops.contains(MemOps::READ) {
             log::error!("there is a region without read permission: {}", range);
             continue;

--- a/monitor/tyche/src/x86_64/monitor.rs
+++ b/monitor/tyche/src/x86_64/monitor.rs
@@ -397,7 +397,10 @@ pub fn do_debug() {
             next_capa = next_next_capa;
             log::trace!(" - {}", info);
         }
-        log::trace!("{}", engine[domain].regions());
+        log::trace!(
+            "{}",
+            engine.get_domain_regions(domain).expect("Invalid domain")
+        );
     }
 }
 
@@ -650,7 +653,7 @@ fn update_domain_ept(domain_handle: Handle<Domain>, engine: &mut MutexGuard<Capa
         ept_root.phys_addr,
     );
 
-    for range in engine[domain_handle].regions().permissions() {
+    for range in engine.get_domain_permissions(domain_handle).unwrap() {
         if !range.ops.contains(MemOps::READ) {
             log::error!("there is a region without read permission: {}", range);
             continue;
@@ -696,7 +699,7 @@ fn update_domain_iopt(domain_handle: Handle<Domain>, engine: &mut MutexGuard<Cap
     );
 
     // Traverse all regions of the I/O domain and maps them into the new iopt
-    for range in engine[domain_handle].regions().permissions() {
+    for range in engine.get_domain_permissions(domain_handle).unwrap() {
         if !range.ops.contains(MemOps::READ) {
             log::error!("there is a region without read permission: {}", range);
             continue;


### PR DESCRIPTION
Remove the per-domain region pool in favor of a global pool. This drastically reduces the memory footprint and makes it possible to use much more regions per domains.

A possible drawback is that the current implementation allows for DoS if a domain consumes too much of the regions from the global pool. This is mitigated by the maximum number of capabilities per domain, but we could also set a counter to allow limiting the number of regions for a given domain.

Potential regressions: used regions might not yet be properly cleaned (it used to be automatic when creating a new domain), this will be part of my next focus area while working on better support for transactionally.