### PR TITLE
Fix memory leak on x86_64 patforms

### DIFF
--- a/monitor/tyche/src/rcframe.rs
+++ b/monitor/tyche/src/rcframe.rs
@@ -48,10 +48,12 @@ pub fn drop_rc(pool: &mut RCFramePool, v: Handle<RCFrame>) {
     if count == 0 {
         let frame = pool[v].frame;
         pool.free(v);
-        unsafe {
-            allocator()
-                .free_frame(frame.phys_addr)
-                .expect("Error freeing frame");
+        if frame.phys_addr.as_u64() != 0 {
+            unsafe {
+                allocator()
+                    .free_frame(frame.phys_addr)
+                    .expect("Error freeing frame");
+            }
         }
     }
 }

--- a/monitor/tyche/src/x86_64/monitor.rs
+++ b/monitor/tyche/src/x86_64/monitor.rs
@@ -31,7 +31,7 @@ use super::vmx_helper::{dump_host_state, load_host_state};
 use super::{cpuid, vmx_helper};
 use crate::allocator::{allocator, PAGE_SIZE};
 use crate::attestation_domain::{attest_domain, calculate_attestation_hash};
-use crate::rcframe::{RCFrame, RCFramePool, EMPTY_RCFRAME};
+use crate::rcframe::{drop_rc, RCFrame, RCFramePool, EMPTY_RCFRAME};
 use crate::sync::Barrier;
 
 // ————————————————————————— Statics & Backend Data ————————————————————————— //
@@ -423,6 +423,7 @@ pub fn do_init_child_context(
         .allocate_frame()
         .expect("Unable to allocate frame");
     let rc = RCFrame::new(frame);
+    drop_rc(&mut *rcvmcs, dest.vmcs);
     dest.vmcs = rcvmcs.allocate(rc).expect("Unable to allocate rc frame");
     //Init the frame, it needs the identifier.
     vmx_state.vmxon.init_frame(frame);


### PR DESCRIPTION
Our RC frame were never de-allocated, causing memory leaks. With this change I run the creation micro-benchmark with 20000 enclaves without running out of memory.