### PR TITLE
Add CI support for the x86 init.sh script

### DIFF
--- a/configs/x86_init.sh
+++ b/configs/x86_init.sh
@@ -29,6 +29,17 @@ Welcome to Tyche
 
 !
 
+# When running on the CI set this to true
+runs_on_ci=false
+
+if [ "$runs_on_ci" = true ] ; then
+    echo "Powering off!"
+    poweroff -f
+    echo "Failed to poweroff"
+
+    exec /bin/sh
+fi
+
 # Open a shell if switch root fail
 error() {
     echo "Failed to switch root to Ubuntu"


### PR DESCRIPTION
On the CI we do not want to run a general purpose Linux distro, but rather we would like to shut down Linux after boot. For this purpose we use a different init script in the CI.
This commit adds the CI script within an `if` statement in our existing x86 init script, defaulting to not running in the CI. To build a CI-ready kernel, set `runs_on_ci` to `true` in the script before re-building busybox and the kernel.