### PR TITLE
Fixed justfile busybox target

### DIFF
--- a/justfile
+++ b/justfile
@@ -201,6 +201,7 @@ _clean-linux-config ARCH:
 ## —————————————————————————————— RamFS Build ——————————————————————————————— ##
 
 build-busybox-x86:
+	@just _build-linux-header-common x86
 	@just _build-busybox-common x86
 
 build-busybox-riscv:
@@ -211,7 +212,7 @@ _build-busybox-common ARCH CROSS_COMPILE=extra_arg:
 	mkdir -p ./builds/busybox-{{ARCH}}
 	cp ./configs/busybox-{{ARCH}}.config ./builds/busybox-{{ARCH}}/.config
 	make -C ./busybox ARCH={{ARCH}} CFLAGS="-I{{build_path}}/linux-headers-{{ARCH}}/include" O=../builds/busybox-{{ARCH}}/ {{CROSS_COMPILE}} -j `nproc`
-	make -C ./busybox ARCH={{ARCH}} O=../builds/busybox-{{ARCH}}/ {{CROSS_COMPILE}} PREFIX=../builds/ramfs-{{ARCH}} install
+	make -C ./busybox ARCH={{ARCH}} CFLAGS="-I{{build_path}}/linux-headers-{{ARCH}}/include" O=../builds/busybox-{{ARCH}}/ {{CROSS_COMPILE}} PREFIX=../builds/ramfs-{{ARCH}} install
 	cp ./configs/{{ARCH}}_init.sh ./builds/ramfs-{{ARCH}}/init
 	chmod a+x  ./builds/ramfs-{{ARCH}}/init
 


### PR DESCRIPTION
Hi all,

just tried to build tyche on a new machine (after having compiled it on several other machines) and ran into issues where the busybox target did not find definitions from the kernel header files (e.g. `TCA_CBQ_MAX ` from `linux/tools/include/uapi/linux/pkt_sched.h`)

For the build I used
```sh
just init-ramfs-x86
just build-busybox-x86
just build-linux-x86
```

I am not sure why I did not encounter these issues earlier. Maybe there was a fallback to the system kernel header files?